### PR TITLE
Showcase skills and resume on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,22 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Blog — Ramin Khaligh</title>
-  <meta name="description" content="Insights on GTM, product marketing, activation, and analytics." />
+  <title>Ramin Khaligh — Marketing & Product Leader</title>
+  <meta name="description" content="Portfolio and insights from Ramin Khaligh, a marketing & product leader available for consulting projects." />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://raminkhaligh.github.io/blog/" />
+  <link rel="canonical" href="https://raminkhaligh.github.io/" />
   <link rel="icon" href="/favicon.ico" />
-  <meta property="og:title" content="Blog — Ramin Khaligh" />
-  <meta property="og:description" content="Insights on GTM, product marketing, activation, and analytics." />
+  <meta property="og:title" content="Ramin Khaligh — Marketing & Product Leader" />
+  <meta property="og:description" content="Portfolio and insights from Ramin Khaligh, a marketing & product leader available for consulting projects." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://raminkhaligh.github.io/blog/" />
-  <meta property="og:image" content="https://raminkhaligh.github.io/assets/og-image.jpg" />
+  <meta property="og:url" content="https://raminkhaligh.github.io/" />
+  <meta property="og:image" content="https://raminkhaligh.github.io/og-image.jpg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Blog — Ramin Khaligh" />
-  <meta name="twitter:description" content="Insights on GTM, product marketing, activation, and analytics." />
-  <meta name="twitter:image" content="https://raminkhaligh.github.io/assets/og-image.jpg" />
+  <meta name="twitter:title" content="Ramin Khaligh — Marketing & Product Leader" />
+  <meta name="twitter:description" content="Portfolio and insights from Ramin Khaligh, a marketing & product leader available for consulting projects." />
+  <meta name="twitter:image" content="https://raminkhaligh.github.io/og-image.jpg" />
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <style>
     :root { color-scheme: light dark; }
@@ -54,31 +54,50 @@
     <a href="/" class="font-extrabold tracking-tight text-xl">RK<span class="text-blue-600">•</span></a>
     <nav class="space-x-6 text-sm font-medium text-gray-700">
       <a href="/">Home</a>
-      <a href="/#projects">Projects</a>
+      <a href="/#skills">Skills</a>
+      <a href="/Ramin_Khaligh_CV.pdf" download>Resume</a>
       <a href="/#contact">Contact</a>
     </nav>
   </div>
 </header>
 <main class="container mx-auto px-6 py-12">
-  <h1 class="text-3xl font-extrabold">Blog & Insights</h1>
-  <p class="mt-3 text-gray-600">Thoughts on product, growth, and GTM.</p>
-  <div class="mt-8 grid md:grid-cols-3 gap-6">
-    <a class="card p-4 hover:shadow" href="/blog/gtm-frameworks.html">
-      <img class="w-full h-40 object-cover rounded-lg" src="https://images.unsplash.com/photo-1553877522-43269d4ea984?q=80&w=1200&auto=format&fit=crop" alt="GTM strategy board">
-      <h3 class="mt-3 font-semibold">A Practical GTM Framework for Product Marketers</h3>
-      <p class="text-sm text-gray-600 mt-1">Define, prioritize, launch, and measure—without chaos.</p>
-    </a>
-    <a class="card p-4 hover:shadow" href="/blog/product-led-activation.html">
-      <img class="w-full h-40 object-cover rounded-lg" src="https://images.unsplash.com/photo-1556761175-4b46a572b786?q=80&w=1200&auto=format&fit=crop" alt="Onboarding sketches">
-      <h3 class="mt-3 font-semibold">Winning Activation with Product‑Led Growth</h3>
-      <p class="text-sm text-gray-600 mt-1">Design nudges that reduce time‑to‑value.</p>
-    </a>
-    <a class="card p-4 hover:shadow" href="/blog/marketing-analytics.html">
-      <img class="w-full h-40 object-cover rounded-lg" src="https://images.unsplash.com/photo-1517148815978-75f6acaaf32c?q=80&w=1200&auto=format&fit=crop" alt="Charts and dashboards">
-      <h3 class="mt-3 font-semibold">Marketing Analytics that Actually Drive Decisions</h3>
-      <p class="text-sm text-gray-600 mt-1">Focus on the few metrics that matter.</p>
-    </a>
-  </div>
+  <section class="text-center mb-12">
+    <h1 class="text-4xl font-extrabold">Ramin Khaligh</h1>
+    <p class="mt-3 text-lg text-gray-600">Marketing & Product leader helping teams launch and grow. Available for consulting projects.</p>
+    <div class="mt-4 flex justify-center gap-4">
+      <a href="#contact" class="btn btn-primary">Work with me</a>
+      <a href="/Ramin_Khaligh_CV.pdf" class="btn border border-blue-600 text-blue-600" download>Download Resume</a>
+    </div>
+  </section>
+
+  <section id="skills">
+    <h2 class="text-3xl font-extrabold">Skills</h2>
+    <div class="mt-6 grid md:grid-cols-2 gap-6">
+      <div>
+        <h3 class="text-xl font-semibold">Hard Skills</h3>
+        <ul class="mt-3 space-y-2 text-gray-700">
+          <li>Product Marketing</li>
+          <li>Growth Strategy</li>
+          <li>Data Analysis</li>
+          <li>Go-to-Market Planning</li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-xl font-semibold">Soft Skills</h3>
+        <ul class="mt-3 space-y-2 text-gray-700">
+          <li>Leadership</li>
+          <li>Cross-functional Collaboration</li>
+          <li>Communication</li>
+          <li>Mentorship</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="mt-16 text-center" id="contact">
+    <h2 class="text-3xl font-extrabold">Let's work together</h2>
+    <p class="mt-3 text-gray-600">Email me at <a class="text-blue-600" href="mailto:hwraamin@gmail.com">hwraamin@gmail.com</a> or connect on <a class="text-blue-600" href="https://www.linkedin.com/in/ramin-khaligh" target="_blank" rel="noopener noreferrer">LinkedIn</a> and <a class="text-blue-600" href="https://www.instagram.com/ramin.khaligh/" target="_blank" rel="noopener noreferrer">Instagram</a>.</p>
+  </section>
 </main>
 <footer class="py-10">
   <div class="container mx-auto px-6 text-sm text-gray-500">© <span id="year"></span> Ramin Khaligh</div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,8 +2,4 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://raminkhaligh.github.io/</loc><priority>1.0</priority></url>
   <url><loc>https://raminkhaligh.github.io/Ramin_Khaligh_CV.pdf</loc><priority>0.5</priority></url>
-  <url><loc>https://raminkhaligh.github.io/blog/</loc></url>
-  <url><loc>https://raminkhaligh.github.io/blog/gtm-frameworks.html</loc></url>
-  <url><loc>https://raminkhaligh.github.io/blog/product-led-activation.html</loc></url>
-  <url><loc>https://raminkhaligh.github.io/blog/marketing-analytics.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- Replace projects and blog sections with a skills overview and resume download
- Add LinkedIn and Instagram links in the contact section for easier networking
- Remove dead blog links from sitemap to avoid 404s

## Testing
- `npx html-validate index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-validate)*
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_b_689757dd8ae4832fa79d43d6ad1332e5